### PR TITLE
fix/remote-backup-cancels

### DIFF
--- a/templates/restic-backup.service.j2
+++ b/templates/restic-backup.service.j2
@@ -6,7 +6,13 @@ Description=Restic backup
 Documentation=https://restic.readthedocs.io
 
 [Service]
+{% if restic_client_is_remote %}
+{# Service should only return after main command completed, to keep the SSH tunnel open during backup #}
+Type=oneshot
+{% else %}
+{# Prefer rather instantaneous prompt return when run interactively #}
 Type=exec
+{% endif %}
 User={{ restic_client_user }}
 Group={{ restic_client_group }}
 AmbientCapabilities=cap_dac_read_search


### PR DESCRIPTION
Fix failing remote backups due to new systemd service type.

New service type 'Type=exec' returns immediately after the 'ExecStart' command of the 'restic-backup.service' executes, leading to a premature SSH tunnel termination on the backup server, disconnecting the client from its restic repository.
Reimplementing the old 'Type=oneshot' for remote clients, the 'systemctl start restic-backup.service' command will only return after the 'ExecStart=restic backup ...' completed on the client, keeping the SSH tunnel open during the whole backup process.