### PR TITLE
Remote improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If LVM is detected on a node, automatic creation of snapshots is included as par
 * Tested with ext4 and xfs filesystems on LVM.
 
 ## Remote pull-style backups
-Backups can be triggered by the backup server, if a client cannot reach the backup server directly. (e.g. due to firewall rules, NAT, etc.) For this, the client must be deployed with `restic_client_is_remote: true` option. This functionality is only tested on a server deployed with the `fifty2technology.restic_server` role, and role `fifty2technology.restic_remote` must be deployed to the client.
+Optionally, backups can be triggered by the backup server, if a client cannot reach the backup server directly. (e.g. due to firewall rules, NAT, etc.) For this, the client must be deployed with `restic_client_is_remote: true` option. This functionality requires a REST-backend backup server deployed with the `fifty2technology.restic_server` role, and role `fifty2technology.restic_remote` must be deployed to the client.
 
 The backup client will be configured with non-active systemd timers for `restic-backup`/`restic-prune` operations in this case. The backup server will be configured to periodically connect to the client via SSH and open a [Remote Port Forwarding](https://www.ssh.com/academy/ssh/tunneling/example#remote-forwarding) to the restic REST backup server. The client is then able to reach the backup server on `127.0.0.1` through the SSH tunnel.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ If LVM is detected on a node, automatic creation of snapshots is included as par
 * Tested with ext4 and xfs filesystems on LVM.
 
 ## Remote pull-style backups
-Backups can be triggered by the backup server, if a client cannot reach the backup server directly. (e.g. due to firewall rules, NAT, etc.) For this, the client must be deployed with `restic_client_is_remote: true` option. This functionality is only tested on a server deployed with the `fifty2technology.restic_server` role, and role `fifty2technology.restic_remote` must be deployed too.
+Backups can be triggered by the backup server, if a client cannot reach the backup server directly. (e.g. due to firewall rules, NAT, etc.) For this, the client must be deployed with `restic_client_is_remote: true` option. This functionality is only tested on a server deployed with the `fifty2technology.restic_server` role, and role `fifty2technology.restic_remote` must be deployed to the client.
 
-The backup client will be configured with a not-activated systemd timer for `backup`/`prune` operations in this case. The backup server will be configured to periodically connect to the client via SSH and open a [Remote Port Forwarding](https://www.ssh.com/academy/ssh/tunneling/example#remote-forwarding) to the restic `rest-server`. The client is then able to reach the `rest-server` on `127.0.0.1` through the SSH tunnel.
+The backup client will be configured with non-active systemd timers for `restic-backup`/`restic-prune` operations in this case. The backup server will be configured to periodically connect to the client via SSH and open a [Remote Port Forwarding](https://www.ssh.com/academy/ssh/tunneling/example#remote-forwarding) to the restic REST backup server. The client is then able to reach the backup server on `127.0.0.1` through the SSH tunnel.
 
 # Requirements
 * Requires `bunzip2` to be installed on the Ansible runner.

--- a/molecule/custom_repository/converge.yml
+++ b/molecule/custom_repository/converge.yml
@@ -8,10 +8,6 @@
     ### We can't test LVM behaviour inside containers, it would use the hosts LVM.
     restic_client_use_lvm: false
     restic_client_repository: "templates/repository.exampleREST.j2"
-    ### Vars for the sake of completeness and successful molecule run, after we
-    ### defined our custom repository file above.
-    restic_fifty2_backup_server: backup.example.com
-    restic_fifty2_backup_server_port: 3000
     restic_fifty2_rest_username: "{{ inventory_hostname }}"
     restic_fifty2_rest_password: "{{ lookup('passwordstore', 'IT/backup/auth/' + inventory_hostname + ' create=true nosymbols=true') }}"
     restic_client_no_log: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,58 +5,76 @@ driver:
   name: podman
 platforms:
   - name: restic_client.debian11-default
-    image: geerlingguy/docker-debian11-ansible:latest  # debian 11 - bullseye
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest  # debian 11 - bullseye
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.debian12-default
-    image: geerlingguy/docker-debian12-ansible:latest  # debian 12 - bookworm
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest  # debian 12 - bookworm
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.ubuntu1804-default
-    image: geerlingguy/docker-ubuntu1804-ansible:latest  # ubuntu 18.04 - bionic
+    image: docker.io/geerlingguy/docker-ubuntu1804-ansible:latest  # ubuntu 18.04 - bionic
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.ubuntu2004-default
-    image: geerlingguy/docker-ubuntu2004-ansible:latest  # ubuntu 20.04 - focal
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest  # ubuntu 20.04 - focal
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.ubuntu2204-default
-    image: geerlingguy/docker-ubuntu2204-ansible:latest  # ubuntu 22.04 - jammy
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest  # ubuntu 22.04 - jammy
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.rockylinux8-default
-    image: geerlingguy/docker-rockylinux8-ansible:latest  # Rocky Linux 8
+    image: docker.io/geerlingguy/docker-rockylinux8-ansible:latest  # Rocky Linux 8
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 
   - name: restic_client.rockylinux9-default
-    image: geerlingguy/docker-rockylinux9-ansible:latest  # Rocky Linux 9
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible:latest  # Rocky Linux 9
+    tmpfs:
+      - /run
+      - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: /sbin/init
     pre_build_image: true
     privileged: true
 provisioner:

--- a/tasks/configure_restic.yml
+++ b/tasks/configure_restic.yml
@@ -31,8 +31,6 @@
     group: "{{ restic_client_group }}"
     mode: '0640'
   no_log: "{{ restic_client_no_log }}"
-  when:
-    - not restic_client_is_remote
 
 - name: Rollout encryption password
   ansible.builtin.copy:

--- a/templates/repository.exampleREST.j2
+++ b/templates/repository.exampleREST.j2
@@ -36,6 +36,7 @@
     the machine's hostname to request specific entries in our passwordstore for
     REST password (and also the encryption password) like this:
     lookup('passwordstore', 'IT/backup/auth/' + inventory_hostname + ' create=true nosymbols=true')
+
     Also see '../molecule/custom_repository/converge.yml' for an applied example
     on how the variables below come together.
 #}
@@ -49,9 +50,11 @@
     get confused with field delimiters in the 'repository' string. #}
 {% set _rest_password            = restic_fifty2_rest_password %}
 
-{#- Set hostname and TCP port of REST server. This information is used in other
-    places too, therefore it's just a reference to variables from 'group_vars/all.yml'. #}
-{% set _backup_server            = restic_fifty2_backup_server %}
-{% set _backup_server_port       = restic_fifty2_backup_server_port -%}
+{#- Set hostname and TCP port of REST server. Lots of defaults here for demonstration
+    in the 'custom_repository' molecule scenario, usually it should be defined
+    in host_vars.
+#}
+{% set _backup_server            = groups['backupservers'][0] | default('backupserver.example.com') %}
+{% set _backup_server_port       = restic_remote_client_port | default(restic_server_listen_port) | default(3000) %}
 
 rest:https://{{ _rest_username }}:{{ _rest_password }}@{{ _backup_server }}:{{ _backup_server_port }}/{{ _rest_username }}


### PR DESCRIPTION
Moves repository templating (esp. REST repositories) to this role exclusively, so we don't need to specify identical information twice here and in `restic_remote`, and don't have to template the `repository` file twice here and in `restic_remote`.

Related PRs: https://github.com/FIFTY2Technology/ansible-role-restic_remote/pull/1 and https://github.com/FIFTY2Technology/ansible-role-restic_server/pull/2